### PR TITLE
Use gobject-2.0 and libunwind for LIBS and CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 HAVE_LIBUNWIND=1
 
 ifeq ($(HAVE_LIBUNWIND), 1)
-	optional_libs=-lunwind
+	optional_libs=libunwind
 	BUILD_OPTIONS+=-DHAVE_LIBUNWIND
 else
 	optional_libs=
 endif
 
-CFLAGS=`pkg-config --cflags glib-2.0`
-LIBS=`pkg-config --libs glib-2.0` $(optional_libs)
+CFLAGS=`pkg-config --cflags gobject-2.0`
+LIBS=`pkg-config --libs gobject-2.0 $(optional_libs)`
 
 
 all: libgobject-list.so


### PR DESCRIPTION
Just linking against glib-2.0 does not suffice, i.e. the linker complains that it cannot find `g_type_name`.