### PR TITLE
Fix an unpaired mutex unlock

### DIFF
--- a/gobject-list.c
+++ b/gobject-list.c
@@ -258,6 +258,8 @@ get_func (const char *func_name)
   void *func;
   char *error;
 
+  G_LOCK (gobject_list);
+
   if (G_UNLIKELY (g_once_init_enter (&handle)))
     {
       void *_handle;


### PR DESCRIPTION
This may have been causing the random memory corruptions. Whoops.
