### PR TITLE
libunwind fixes (compile fix, fix error condition/message)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,24 @@ else
 	optional_libs=
 endif
 
+CC ?= cc
 FLAGS=`pkg-config --cflags gobject-2.0`
 LIBS=`pkg-config --libs gobject-2.0 $(optional_libs)`
 
+OBJS = gobject-list.o
 
 all: libgobject-list.so
+.PHONY: all clean
 clean:
-	rm -f libgobject-list.so gobject-list.o
+	rm -f libgobject-list.so $(OBJS)
 
-libgobject-list.so: gobject-list.c
+%.o: %.c
+	$(CC) -fPIC -rdynamic -g -c -Wall ${FLAGS} ${BUILD_OPTIONS} $<
+
+libgobject-list.so: $(OBJS)
 ifeq ($(HAVE_LIBUNWIND), 1)
 	@echo "Building with backtrace support (libunwind)"
 else
 	@echo "Building without backtrace support (libunwind disabled)"
 endif
-	$(CC) -fPIC -rdynamic -g -c -Wall ${FLAGS} ${BUILD_OPTIONS} $<
-	$(CC) -shared -Wl,-soname,$@ -o $@ gobject-list.o -lc -ldl ${LIBS}
+	$(CC) -shared -Wl,-soname,$@ -o $@ $^ -lc -ldl ${LIBS}

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 	rm -f libgobject-list.so $(OBJS)
 
 %.o: %.c
-	$(CC) -fPIC -rdynamic -g -c -Wall ${FLAGS} ${BUILD_OPTIONS} $<
+	$(CC) -fPIC -rdynamic -g -c -Wall -Wextra ${FLAGS} ${BUILD_OPTIONS} $<
 
 libgobject-list.so: $(OBJS)
 ifeq ($(HAVE_LIBUNWIND), 1)

--- a/gobject-list.c
+++ b/gobject-list.c
@@ -166,10 +166,11 @@ print_trace (void)
       unw_word_t off;
       int result;
 
-      result = unw_get_proc_name (&cursor, name, sizeof (name) - 1, &off);
-      if (result < 0 && result != UNW_ENOMEM)
+      result = unw_get_proc_name (&cursor, name, sizeof (name), &off);
+      if (result < 0 && result != -UNW_ENOMEM)
         {
-          g_print ("Error getting proc name\n");
+          g_print ("Error getting frame: %s (%d)\n",
+                   unw_strerror (result), -result);
           break;
         }
 

--- a/gobject-list.c
+++ b/gobject-list.c
@@ -124,6 +124,10 @@ display_filter (DisplayFlags flags)
 
           g_strfreev (tokens);
         }
+#ifndef HAVE_LIBUNWIND
+      if (display_flags & DISPLAY_FLAG_BACKTRACE)
+        g_print ("Warning: backtrace is not available, it needs libunwind\n");
+#endif
 
       parsed = TRUE;
     }
@@ -171,6 +175,7 @@ print_trace (void)
 
       g_print ("#%d  %s + [0x%08x]\n", stack_num++, name, (unsigned int)off);
     }
+#endif
 }
 
 static void
@@ -190,7 +195,6 @@ _dump_object_list (GHashTable *hash)
           obj, G_OBJECT_TYPE_NAME (obj), obj->ref_count);
     }
   g_print ("%u objects\n", g_hash_table_size (hash));
-#endif
 }
 
 static void

--- a/gobject-list.c
+++ b/gobject-list.c
@@ -199,7 +199,7 @@ _dump_object_list (GHashTable *hash)
 }
 
 static void
-_sig_usr1_handler (int signal)
+_sig_usr1_handler (G_GNUC_UNUSED int signal)
 {
   g_print ("Living Objects:\n");
 
@@ -209,7 +209,7 @@ _sig_usr1_handler (int signal)
 }
 
 static void
-_sig_usr2_handler (int signal)
+_sig_usr2_handler (G_GNUC_UNUSED int signal)
 {
   GHashTableIter iter;
   gpointer obj, type;
@@ -315,7 +315,7 @@ get_func (const char *func_name)
 }
 
 static void
-_object_finalized (gpointer data,
+_object_finalized (G_GNUC_UNUSED gpointer data,
     GObject *obj)
 {
   G_LOCK (gobject_list);


### PR DESCRIPTION
Fixes a compile warning when LIBUNWIND is disabled,
fixes a truncated backtrace and improve the error message.

Two latter commits are for development.