### PR TITLE
Fix string comparison in object type filter

### DIFF
--- a/gobject-list.c
+++ b/gobject-list.c
@@ -143,7 +143,7 @@ object_filter (const char *obj_name)
   if (filter == NULL)
     return TRUE;
   else
-    return (strncmp (filter, obj_name, strlen (filter)) == 0);
+    return (g_strcmp0 (filter, obj_name) == 0);
 }
 
 static void


### PR DESCRIPTION
The object type filter used strncmp() to compare object
type names, but limited the comparison to the length of the
filter string. For example, a filter of 'GstPad' would display
both 'GstPad' and 'GstPadTemplate' types.

Use g_strcmp0() instead, it uses the entirety of both strings
when comparing.